### PR TITLE
Adds js check for sites not using sticky menu

### DIFF
--- a/assets/scripts/routes/common.js
+++ b/assets/scripts/routes/common.js
@@ -28,7 +28,9 @@ export default {
 
     // Assign sticky
     var $sticky = document.getElementsByClassName('navbar-sticky-top');
-    Stickyfill.add($sticky[0]);
+    if($sticky.length) {
+      Stickyfill.add($sticky[0]);
+    }
   },
   finalize() {
     // JavaScript to be fired on all pages, after page specific JS is fired


### PR DESCRIPTION
Prevents error when no elements have class 'navbar-sticky-top'