### PR TITLE
Skip optional dev deployment without environment file

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -57,13 +57,14 @@ jobs:
 
       - name: Get .env Variables
         id: dotenv
+        if: ${{ hashFiles('.env') != '' }}
         uses: falti/dotenv-action@v1.0.4
 
       - name: Sync Files to Server
         env:
           dest: "${{ steps.dotenv.outputs.SSH_LOGIN }}:${{ steps.dotenv.outputs.DEPLOYMENT_PATH }}${{ steps.dotenv.outputs.VITE_THEME_PATH }}"
           deploy: "${{ steps.dotenv.outputs.DEPLOY }}"
-        if: ${{ env.deploy == 'TRUE' }}
+        if: ${{ steps.dotenv.outcome == 'success' && env.deploy == 'TRUE' }}
         run: |
           echo "${{ secrets.DEPLOY_KEY }}" > deploy_key
           chmod 600 ./deploy_key


### PR DESCRIPTION
## Summary

- skip dotenv parsing when the Actions checkout has no .env file
- run the server sync only when dotenv parsing succeeded and DEPLOY is TRUE
- keep dependency installation and the production asset build mandatory

## Root cause

The Development Build completed Composer installation, npm installation, and Vite compilation successfully. It then failed in falti/dotenv-action because .env is intentionally untracked and therefore absent from the GitHub Actions checkout.

## Impact

Normal dev pushes can validate the project without requiring deployment credentials. Existing deployments remain opt-in through an available .env file with DEPLOY=TRUE.

## Validation

- workflow YAML parsed successfully
- Composer install and manifest validation
- Composer audit: zero advisories
- Node 22.22.0 npm ci
- production Vite build

## Follow-up

npm currently reports two high-severity advisories in build-tool dependencies when audited with dev dependencies omitted. The release ZIP excludes node_modules, so they are not shipped, but they should be updated before tagging alpha.8.
