### PR TITLE
Fix admin notice release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,19 @@ jobs:
           (cd build && zip -rq "../dist-release/${SLUG}.zip" "${SLUG}")
           ls -la dist-release/
 
+      - name: Verify theme zip
+        run: |
+          set -euo pipefail
+          SLUG="${{ github.event.repository.name }}"
+          ZIP="dist-release/${SLUG}.zip"
+          EXTRACT_DIR="$(mktemp -d)"
+          unzip -t "${ZIP}"
+          unzip -q "${ZIP}" -d "${EXTRACT_DIR}"
+          test -f "${EXTRACT_DIR}/${SLUG}/dist/.vite/manifest.json"
+          grep -R -q --include='*.css' \
+            'body.tofino-hide-admin-notices' \
+            "${EXTRACT_DIR}/${SLUG}/dist/assets"
+
       - uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}

--- a/features/hide-admin-notices/admin.css
+++ b/features/hide-admin-notices/admin.css
@@ -22,12 +22,31 @@
  * so plugins that measure notice dimensions on load don't misbehave.
  */
 
-body.tofino-hide-admin-notices #wpbody-content > .wrap > .notice:not(.system-notice):not(.update-message):not(.inline):not(.hidden):not(.settings-error):not(.acf-admin-notice):not(#message),
-body.tofino-hide-admin-notices #wpbody-content > .wrap > div.updated:not(.inline):not(.hidden):not(.settings-error):not(.acf-admin-notice):not(#message),
-body.tofino-hide-admin-notices #wpbody-content > .wrap > div.error:not(.inline):not(.hidden):not(.settings-error):not(.acf-admin-notice):not(#message),
-body.tofino-hide-admin-notices #wpbody-content > .notice:not(.system-notice):not(.update-message):not(.inline):not(.hidden):not(.settings-error):not(.acf-admin-notice):not(#message),
-body.tofino-hide-admin-notices #wpbody-content > div.updated:not(.inline):not(.hidden):not(.settings-error):not(.acf-admin-notice):not(#message),
-body.tofino-hide-admin-notices #wpbody-content > div.error:not(.inline):not(.hidden):not(.settings-error):not(.acf-admin-notice):not(#message) {
+body.tofino-hide-admin-notices
+  #wpbody-content
+  > .wrap
+  > .notice:not(.system-notice):not(.update-message):not(.inline):not(.hidden):not(
+    .settings-error
+  ):not(.acf-admin-notice):not(#message),
+body.tofino-hide-admin-notices
+  #wpbody-content
+  > .wrap
+  > div.updated:not(.inline):not(.hidden):not(.settings-error):not(.acf-admin-notice):not(#message),
+body.tofino-hide-admin-notices
+  #wpbody-content
+  > .wrap
+  > div.error:not(.inline):not(.hidden):not(.settings-error):not(.acf-admin-notice):not(#message),
+body.tofino-hide-admin-notices
+  #wpbody-content
+  > .notice:not(.system-notice):not(.update-message):not(.inline):not(.hidden):not(
+    .settings-error
+  ):not(.acf-admin-notice):not(#message),
+body.tofino-hide-admin-notices
+  #wpbody-content
+  > div.updated:not(.inline):not(.hidden):not(.settings-error):not(.acf-admin-notice):not(#message),
+body.tofino-hide-admin-notices
+  #wpbody-content
+  > div.error:not(.inline):not(.hidden):not(.settings-error):not(.acf-admin-notice):not(#message) {
   position: absolute !important;
   visibility: hidden !important;
 }

--- a/features/hide-admin-notices/feature.json
+++ b/features/hide-admin-notices/feature.json
@@ -1,6 +1,7 @@
 {
   "title": "Hide Admin Notices",
   "scope": "admin",
+  "css": "admin.css",
   "acf": "fields.php",
   "render": "render.php"
 }

--- a/features/hide-admin-notices/fields.php
+++ b/features/hide-admin-notices/fields.php
@@ -36,6 +36,7 @@ acf_add_local_field_group([
       'multiple' => 1,
       'ui' => 1,
       'return_format' => 'value',
+      'default_value' => ['administrator'],
     ],
     [
       'key' => 'field_notices_panel_roles',
@@ -47,6 +48,7 @@ acf_add_local_field_group([
       'multiple' => 1,
       'ui' => 1,
       'return_format' => 'value',
+      'default_value' => ['administrator'],
     ],
   ],
   'location' => [

--- a/features/hide-admin-notices/render.php
+++ b/features/hide-admin-notices/render.php
@@ -24,17 +24,17 @@ class HideAdminNotices
   private array $panel_roles = [];
 
   /**
-   * Constructor. Defers initialisation until ACF has loaded so
-   * get_field() can safely read the role settings.
+   * Constructor. Defers initialisation until after the feature registry has
+   * registered its local ACF fields so unsaved defaults are available.
    */
   public function __construct()
   {
-    add_action('acf/init', [$this, 'initialize']);
+    add_action('acf/init', [$this, 'initialize'], 30);
   }
 
   /**
    * Reads the role settings and registers the admin hooks that power the
-   * feature (hidden admin page, admin bar node, body class, stylesheet).
+   * feature (hidden admin page, admin bar node, and body class).
    */
   public function initialize(): void
   {
@@ -43,7 +43,6 @@ class HideAdminNotices
 
     add_action('admin_menu', [$this, 'register_page']);
     add_action('admin_bar_menu', [$this, 'add_admin_bar_node'], 100);
-    add_action('admin_enqueue_scripts', [$this, 'enqueue_style']);
     add_filter('admin_body_class', [$this, 'add_body_class']);
   }
 
@@ -189,31 +188,6 @@ class HideAdminNotices
     }
 
     return trim($classes . ' tofino-hide-admin-notices');
-  }
-
-  /**
-   * Enqueues the stylesheet that visually hides admin notices. Gated
-   * identically to add_body_class() — skipped on the Notices page itself
-   * and for users outside hide_notices_roles.
-   *
-   * @return void
-   */
-  public function enqueue_style(): void
-  {
-    if ($this->is_notices_page()) {
-      return;
-    }
-
-    if (!$this->user_has_role($this->hide_roles)) {
-      return;
-    }
-
-    wp_enqueue_style(
-      'tofino-hide-admin-notices',
-      get_template_directory_uri() . '/features/hide-admin-notices/style.css',
-      [],
-      wp_get_theme()->get('Version')
-    );
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tofino",
-  "version": "5.0.0-alpha.8",
+  "version": "5.0.0-alpha.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tofino",
-      "version": "5.0.0-alpha.8",
+      "version": "5.0.0-alpha.9",
       "dependencies": {
         "@apollo/client": "^3.14.0",
         "@axe-core/playwright": "^4.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tofino",
   "private": true,
-  "version": "5.0.0-alpha.8",
+  "version": "5.0.0-alpha.9",
   "description": "A WordPress starter theme for jumpstarting custom theme development.",
   "keywords": [
     "WordPress",

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:        Tofino
 Theme URI:         https://github.com/creativedotdesign/tofino
 Description:       Tofino is a WordPress starter theme.
-Version:           5.0.0-alpha.8
+Version:           5.0.0-alpha.9
 Author:            Creative Dot
 Author URI:        https://creativedotdesign.com
 Text Domain:       tofino


### PR DESCRIPTION
## What changed

- bundle Hide Admin Notices CSS into Tofino's production admin asset
- remove the direct source-CSS enqueue that pointed to a file excluded from release archives
- default both role settings to Administrator on unsaved fresh installations
- initialize the runtime after local ACF fields are registered so those defaults are available
- prepare version 5.0.0-alpha.9
- verify release ZIP integrity and assert that the compiled notice selector is present

## Root cause

The release archive intentionally excludes `features/**/*.css` because feature CSS is expected to be compiled into `dist/`. Hide Admin Notices used a front-end-style filename and also enqueued that source file directly. The published archive therefore omitted the file, the live URL returned 404, and no hide rule was applied even after the Administrator role was saved.

## Validation

- Node 22 Vite production build
- generated admin manifest/CSS inspection
- release-equivalent ZIP build, integrity check, single-root check, version check, and compiled-selector assertion
- Composer strict validation, production install, and audit
- npm audit (0 vulnerabilities)
- all PHP files linted
- Prettier checks
- ACF default-role and initialization-priority assertions
