### PR TITLE
Prepare Tofino 5.0.0-alpha.10 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ node_modules/
 # ignore dist directories
 dist/
 dist/hot
+/build/
+/dist-release/
 
 # ignore npm debug log file
 npm-debug.log

--- a/features/hide-admin-notices/render.php
+++ b/features/hide-admin-notices/render.php
@@ -38,8 +38,9 @@ class HideAdminNotices
    */
   public function initialize(): void
   {
-    $this->hide_roles = $this->normalise_roles(get_field('hide_notices_roles', 'option'));
-    $this->panel_roles = $this->normalise_roles(get_field('notices_panel_roles', 'option'));
+    // Field keys let ACF resolve defaults before option meta references exist.
+    $this->hide_roles = $this->normalise_roles(get_field('field_hide_notices_roles', 'option'));
+    $this->panel_roles = $this->normalise_roles(get_field('field_notices_panel_roles', 'option'));
 
     add_action('admin_menu', [$this, 'register_page']);
     add_action('admin_bar_menu', [$this, 'add_admin_bar_node'], 100);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tofino",
-  "version": "5.0.0-alpha.9",
+  "version": "5.0.0-alpha.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tofino",
-      "version": "5.0.0-alpha.9",
+      "version": "5.0.0-alpha.10",
       "dependencies": {
         "@apollo/client": "^3.14.0",
         "@axe-core/playwright": "^4.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tofino",
   "private": true,
-  "version": "5.0.0-alpha.9",
+  "version": "5.0.0-alpha.10",
   "description": "A WordPress starter theme for jumpstarting custom theme development.",
   "keywords": [
     "WordPress",

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
 Theme Name:        Tofino
 Theme URI:         https://github.com/creativedotdesign/tofino
 Description:       Tofino is a WordPress starter theme.
-Version:           5.0.0-alpha.9
+Version:           5.0.0-alpha.10
 Author:            Creative Dot
 Author URI:        https://creativedotdesign.com
 Text Domain:       tofino

--- a/theme/Integrations/GraphQL.php
+++ b/theme/Integrations/GraphQL.php
@@ -42,7 +42,14 @@ class GraphQL
    */
   public function add_endpoint_to_localize_data(array $data): array
   {
-    $data['graphqlEndpoint'] = graphql_get_endpoint();
+    $endpoint_url = function_exists('graphql_get_endpoint_url')
+      ? graphql_get_endpoint_url()
+      : site_url(graphql_get_endpoint());
+    $endpoint_path = wp_parse_url($endpoint_url, PHP_URL_PATH);
+
+    $data['graphqlEndpoint'] = is_string($endpoint_path)
+      ? ltrim($endpoint_path, '/')
+      : graphql_get_endpoint();
 
     return $data;
   }


### PR DESCRIPTION
## Summary

- make unsaved Hide Admin Notices role defaults effective on fresh installations
- localize the WPGraphQL endpoint with the WordPress site path so `/wp` installations request `/wp/graphql`
- bump release metadata to `5.0.0-alpha.10`
- ignore generated local release-package directories

## Root cause

ACF displays field defaults before an options field has been saved, but name-based value lookup cannot resolve that field without stored reference metadata. Separately, the GraphQL payload exposed only the endpoint slug and omitted the WordPress subdirectory used by the production deployment.

## Impact

Fresh administrators receive the configured notice behavior without first saving the options page, and all consumers of `tofinoJS.graphqlEndpoint` receive a path that works for both root and subdirectory WordPress installations.

## Validation

- simulated `site_url` with `/wp` and confirmed `graphqlEndpoint` becomes `wp/graphql`
- clean npm install and audit: 0 vulnerabilities
- Vite production build
- Composer strict validation and audit: 0 advisories
- all theme PHP files linted
- packaged and verified `tofino.zip`, including version `5.0.0-alpha.10`, compiled manifest, and Hide Admin Notices CSS
- local ZIP SHA-256: `bb45ab3d0f012d4ae6fa366d31c48f35b2a1c8d1355d9adf9b08dca939b60775`
